### PR TITLE
Fix macOS build instructions for argp-standalone

### DIFF
--- a/nprint/install.md
+++ b/nprint/install.md
@@ -23,14 +23,52 @@ nav_order: 1
 
 `sudo apt-get install libpcap-dev`
 
-### Install dependencies on Mac OS
+### Install dependencies on macOS
 
-`brew install argp-standalone`
+```bash
+brew install argp-standalone autoconf automake libtool
+```
 
 ## Install
+
+### Building from source (latest development version)
+
+```bash
+git clone https://github.com/nprint/nprint.git
+cd nprint
+autoreconf -i
+```
+
+**On Debian/Linux:**
+```bash
+./configure
+make
+sudo make install
+```
+
+**On macOS:**
+```bash
+./configure CPPFLAGS="-I/opt/homebrew/opt/argp-standalone/include" LDFLAGS="-L/opt/homebrew/opt/argp-standalone/lib"
+make
+sudo make install
+```
+
+### Installing from release tarball
 
 1. Download the latest release tar [here](https://github.com/nprint/nprint/releases/)
 2. Extract the tar `tar -xvf [nprint-version.tar.gz]`
 3. `cd [nprint-directory]`
 
-2. `./configure && make && sudo make install`
+**On Debian/Linux:**
+```bash
+./configure
+make
+sudo make install
+```
+
+**On macOS:**
+```bash
+./configure CPPFLAGS="-I/opt/homebrew/opt/argp-standalone/include" LDFLAGS="-L/opt/homebrew/opt/argp-standalone/lib"
+make
+sudo make install
+```


### PR DESCRIPTION
## Summary

This PR updates the website documentation to match the fix applied to the main repository README (nprint/nprint#50).

## Changes

- Updated `nprint/install.md` with proper `configure` command for macOS that passes `argp-standalone` include and library paths via `CPPFLAGS` and `LDFLAGS`
- Added `autoconf`, `automake`, and `libtool` to the macOS dependency installation instructions (required for building from source)
- Reorganized installation section to clearly separate Linux and macOS build steps
- Added instructions for both building from source (git clone) and from release tarballs

## Context

This addresses the same issue as nprint/nprint#48 - macOS users were encountering compilation errors because `argp.h` couldn't be found. The solution is to pass the proper Homebrew paths to the `configure` script instead of manually editing the Makefile.

## Testing

Successfully built and installed nprint on macOS Sequoia (Apple Silicon) using these instructions.